### PR TITLE
Fixing Fan Art

### DIFF
--- a/plugin.video.animevice/default.py
+++ b/plugin.video.animevice/default.py
@@ -125,6 +125,7 @@ def addLink(name, url, iconimage):
     ok=True
     liz=xbmcgui.ListItem(name, iconImage="DefaultVideo.png", thumbnailImage=iconimage)
     liz.setInfo( type="Video", infoLabels={ "Title": name } )
+    liz.setProperty("fanart_image", "special://home/addons/plugin.video.animevice/fanart.jpg")
     ok=xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]),url=url,listitem=liz)
     return ok
 
@@ -133,6 +134,7 @@ def addDir(name, url, mode, iconimage):
     ok=True
     liz=xbmcgui.ListItem(name, iconImage="DefaultFolder.png", thumbnailImage=iconimage)
     liz.setInfo( type="Video", infoLabels={ "Title": name } )
+    liz.setProperty("fanart_image", "special://home/addons/plugin.video.animevice/fanart.jpg")
     ok=xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]),url=u,listitem=liz,isFolder=True)
     return ok
 

--- a/plugin.video.comicvine/default.py
+++ b/plugin.video.comicvine/default.py
@@ -125,6 +125,7 @@ def addLink(name, url, iconimage):
     ok=True
     liz=xbmcgui.ListItem(name, iconImage="DefaultVideo.png", thumbnailImage=iconimage)
     liz.setInfo( type="Video", infoLabels={ "Title": name } )
+    liz.setProperty("fanart_image", "special://home/addons/plugin.video.comicvine/fanart.jpg")
     ok=xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]),url=url,listitem=liz)
     return ok
 
@@ -132,6 +133,7 @@ def addDir(name, url, mode, iconimage):
     u=sys.argv[0]+"?url="+urllib.quote_plus(url)+"&mode="+str(mode)+"&name="+urllib.quote_plus(name)
     ok=True
     liz=xbmcgui.ListItem(name, iconImage="DefaultFolder.png", thumbnailImage=iconimage)
+    liz.setProperty("fanart_image", "special://home/addons/plugin.video.comicvine/fanart.jpg")
     liz.setInfo( type="Video", infoLabels={ "Title": name } )
     ok=xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]),url=u,listitem=liz,isFolder=True)
     return ok

--- a/plugin.video.giantbomb/default.py
+++ b/plugin.video.giantbomb/default.py
@@ -153,6 +153,7 @@ def addLink(name, url, iconimage):
     ok=True
     liz=xbmcgui.ListItem(name, iconImage="DefaultVideo.png", thumbnailImage=iconimage)
     liz.setInfo( type="Video", infoLabels={ "Title": name } )
+    liz.setProperty("fanart_image", "special://home/addons/plugin.video.giantbomb/fanart.jpg")
     ok=xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]),url=url,listitem=liz)
     return ok
 
@@ -161,6 +162,7 @@ def addDir(name, url, mode, iconimage):
     ok=True
     liz=xbmcgui.ListItem(name, iconImage="DefaultFolder.png", thumbnailImage=iconimage)
     liz.setInfo( type="Video", infoLabels={ "Title": name } )
+    liz.setProperty("fanart_image", "special://home/addons/plugin.video.giantbomb/fanart.jpg")
     ok=xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]),url=u,listitem=liz,isFolder=True)
     return ok
 

--- a/plugin.video.screened/default.py
+++ b/plugin.video.screened/default.py
@@ -125,6 +125,7 @@ def addLink(name, url, iconimage):
     ok=True
     liz=xbmcgui.ListItem(name, iconImage="DefaultVideo.png", thumbnailImage=iconimage)
     liz.setInfo( type="Video", infoLabels={ "Title": name } )
+    liz.setProperty("fanart_image", "special://home/addons/plugin.video.screened/fanart.jpg")
     ok=xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]),url=url,listitem=liz)
     return ok
 
@@ -133,6 +134,7 @@ def addDir(name, url, mode, iconimage):
     ok=True
     liz=xbmcgui.ListItem(name, iconImage="DefaultFolder.png", thumbnailImage=iconimage)
     liz.setInfo( type="Video", infoLabels={ "Title": name } )
+    liz.setProperty("fanart_image", "special://home/addons/plugin.video.screened/fanart.jpg")
     ok=xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]),url=u,listitem=liz,isFolder=True)
     return ok
 


### PR DESCRIPTION
Hope I did this right? First time using github & first time working in python.

Currently fanart is only set in the top level of the plugin, reverting back to the skin default background when drilling down into the categories.

I've added a couple of lines in each 'add on' which sets the fan art for each directory and item.

Currently the address of the fanart.jpg is hard coded but I'm sure there's a way to dynamically generate the address, but I'm not familiar enough with python or XBMC's internal workings.
