### PR TITLE
Fixed the Giantbomb plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+__THIS IS NO LONGER SUPPORTED__
+
+You an find an even better and supported version here: https://github.com/jimporter/giantbomb-kodi/releases

--- a/plugin.video.giantbomb/addon.xml
+++ b/plugin.video.giantbomb/addon.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.giantbomb"
        name="Giant Bomb"
-       version="3.6"
+       version="3.6.1"
        provider-name="Whiskey Media">
   <requires>
-    <import addon="xbmc.python" version="2.0"/>
+    <import addon="xbmc.python" version="2.1.0"/>
     <import addon="script.module.simplejson" version="2.0.10"/>
   </requires>
   <extension point="xbmc.python.pluginsource"

--- a/plugin.video.giantbomb/addon.xml
+++ b/plugin.video.giantbomb/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.giantbomb"
        name="Giant Bomb"
-       version="3.5"
+       version="3.6"
        provider-name="Whiskey Media">
   <requires>
     <import addon="xbmc.python" version="2.0"/>

--- a/plugin.video.giantbomb/changelog.txt
+++ b/plugin.video.giantbomb/changelog.txt
@@ -1,3 +1,6 @@
+[B]3.6[/B]
+- Using the new API URL to fix the plugin.
+
 [B]3.5[/B]
 - Added Chrono Trigger endurance run submenu
 

--- a/plugin.video.giantbomb/default.py
+++ b/plugin.video.giantbomb/default.py
@@ -5,7 +5,7 @@ import xbmcaddon
 import xbmcplugin
 import xbmcgui
 
-API_PATH = 'http://api.giantbomb.com'
+API_PATH = 'http://www.giantbomb.com/api'
 API_KEY = 'fa96542d69b4af7f31c2049ace5d89e84e225bef' # Default API key
 my_addon = xbmcaddon.Addon('plugin.video.giantbomb')
 

--- a/plugin.video.giantbomb/default.py
+++ b/plugin.video.giantbomb/default.py
@@ -142,9 +142,15 @@ def VIDEOLINKS(url, name):
             if 'hd_url' in vid:
                 url = vid['hd_url'] + '&api_key=' + API_KEY
             else:
-                url = vid['high_url']
+                if vid['high_url'] is not None:
+                    url = vid['high_url']
+                else:
+                    continue
         else:
-            url = vid[quality]
+            if vid[quality] is not None:
+                url = vid[quality]
+            else:
+                continue
         thumbnail = vid['image']['super_url']
         addLink(name,url,thumbnail)
 

--- a/plugin.video.giantbomb/default.py
+++ b/plugin.video.giantbomb/default.py
@@ -13,7 +13,7 @@ def CATEGORIES():
     account_linked = False
     user_api_key = my_addon.getSetting('api_key')
     if user_api_key:
-        response = urllib2.urlopen(API_PATH + '/chats/?api_key=' + user_api_key + '&format=json')
+        response = urllib2.urlopen(API_PATH + '/video_types/?api_key=' + user_api_key + '&format=json')
         data = simplejson.loads(response.read())
         if data['status_code'] == 100:
             # Revert to the default key


### PR DESCRIPTION
The giantbomb plugin is now using the API url: www.giantbomb.com/api, instead of api.giantbomb.com. I also had to change the response test to use a different URL as /chats/ was no longer responding.

This plugin will need to be updated in the add-on repository too.
